### PR TITLE
churn: delete warnings on typeorm execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
    },
    "scripts": {
       "start": "node --loader ts-node/esm src/index.ts",
-      "migration:create": "node --loader ts-node/esm ./node_modules/.bin/typeorm migration:create",
-      "migration:generate": "node --loader ts-node/esm ./node_modules/.bin/typeorm migration:generate -d ./src/data-source.ts",
-      "migration:up": "node --loader ts-node/esm ./node_modules/.bin/typeorm migration:run -d ./src/data-source.ts",
-      "migration:down": "node --loader ts-node/esm ./node_modules/.bin/typeorm migration:revert -d ./src/data-source.ts"
+      "typeorm": "ts-node ./node_modules/.bin/typeorm",
+      "migration:create": "npm run typeorm -- migration:create",
+      "migration:generate": "npm run typeorm -- migration:generate -d ./src/data-source.ts",
+      "migration:up": "npm run typeorm -- migration:run -d ./src/data-source.ts",
+      "migration:down": "npm run typeorm -- migration:revert -d ./src/data-source.ts"
    }
 }


### PR DESCRIPTION
That changes are gonna remove the following warning on executing any typeorm command

```bash
...
> node --loader ts-node/esm ./node_modules/.bin/typeorm "migration:run" "-d" "./src/database/data-source.ts"

(node:3167) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)

....
```